### PR TITLE
fix: remove deleted fields on refresh

### DIFF
--- a/src/components/Collection/CollectionEdit.vue
+++ b/src/components/Collection/CollectionEdit.vue
@@ -98,6 +98,11 @@ export default {
             }));
         },
     },
+    watch: {
+        'database.table'() {
+            this.refreshFields();
+        },
+    },
     mounted() {
         this.definitions = this.plugin.doc.definitions || {};
     },
@@ -107,7 +112,7 @@ export default {
                 this.isLoading = true;
                 await this.plugin.fetchDoc();
                 this.definitions = this.plugin.doc.definitions || {};
-                this.refreshFields()
+                this.refreshFields();
             } catch (err) {
                 wwLib.wwLog.error(err);
             } finally {
@@ -115,10 +120,12 @@ export default {
             }
         },
         refreshFields() {
-            const primaryData = this.primaryProperties.map(primaryProperty => primaryProperty.name)
+            const primaryData = this.primaryProperties.map(primaryProperty => primaryProperty.name);
             // clear removed fields
-            const dataFields = this.database.dataFields.filter(field => this.tableProperties.some(prop => prop.name === field))
-            
+            const dataFields = this.database.dataFields.filter(field =>
+                this.tableProperties.some(prop => prop.name === field)
+            );
+
             this.$emit('update:config', { ...this.database, primaryData, dataFields });
         },
         setProp(key, value) {

--- a/src/components/Functions/Delete.vue
+++ b/src/components/Functions/Delete.vue
@@ -91,11 +91,20 @@ export default {
                 this.isLoading = true;
                 await this.plugin.fetchDoc();
                 this.definitions = this.plugin.doc.definitions || {};
+                this.refreshFields();
             } catch (err) {
                 wwLib.wwLog.error(err);
             } finally {
                 this.isLoading = false;
             }
+        },
+        refreshFields() {
+            // clear removed fields
+            const primaryData = { ...this.args.primaryData };
+            for (const key in primaryData) {
+                if (!this.tableProperties.includes(key)) delete primaryData[key];
+            }
+            this.setPrimaryData(primaryData);
         },
     },
 };

--- a/src/components/Functions/Insert.vue
+++ b/src/components/Functions/Insert.vue
@@ -118,11 +118,18 @@ export default {
                 this.isLoading = true;
                 await this.plugin.fetchDoc();
                 this.definitions = this.plugin.doc.definitions || {};
+                this.refreshFields();
             } catch (err) {
                 wwLib.wwLog.error(err);
             } finally {
                 this.isLoading = false;
             }
+        },
+        refreshFields() {
+            // clear removed fields
+            this.setDataFields(
+                this.args.dataFields.filter(field => this.tableProperties.some(prop => prop.name === field))
+            );
         },
     },
 };

--- a/src/components/Functions/Select.vue
+++ b/src/components/Functions/Select.vue
@@ -97,6 +97,7 @@ export default {
     },
     mounted() {
         this.definitions = this.plugin.doc.definitions || {};
+        if (!this.args.fieldsMode) this.setFieldsMode('guided');
     },
     methods: {
         setTable(table) {
@@ -116,11 +117,18 @@ export default {
                 this.isLoading = true;
                 await this.plugin.fetchDoc();
                 this.definitions = this.plugin.doc.definitions || {};
+                this.refreshFields();
             } catch (err) {
                 wwLib.wwLog.error(err);
             } finally {
                 this.isLoading = false;
             }
+        },
+        refreshFields() {
+            // clear removed fields
+            this.setDataFields(
+                this.args.dataFields.filter(field => this.tableProperties.some(prop => prop.name === field))
+            );
         },
     },
 };

--- a/src/components/Functions/Update.vue
+++ b/src/components/Functions/Update.vue
@@ -160,11 +160,18 @@ export default {
                 this.isLoading = true;
                 await this.plugin.fetchDoc();
                 this.definitions = this.plugin.doc.definitions || {};
+                this.refreshFields();
             } catch (err) {
                 wwLib.wwLog.error(err);
             } finally {
                 this.isLoading = false;
             }
+        },
+        refreshFields() {
+            // clear removed fields
+            this.setDataFields(
+                this.args.dataFields.filter(field => this.tableProperties.some(prop => prop.name === field))
+            );
         },
     },
 };

--- a/src/components/Functions/Upsert.vue
+++ b/src/components/Functions/Upsert.vue
@@ -118,11 +118,18 @@ export default {
                 this.isLoading = true;
                 await this.plugin.fetchDoc();
                 this.definitions = this.plugin.doc.definitions || {};
+                this.refreshFields();
             } catch (err) {
                 wwLib.wwLog.error(err);
             } finally {
                 this.isLoading = false;
             }
+        },
+        refreshFields() {
+            // clear removed fields
+            this.setDataFields(
+                this.args.dataFields.filter(field => this.tableProperties.some(prop => prop.name === field))
+            );
         },
     },
 };


### PR DESCRIPTION
@Dams-d Il servait toujours ce watch ? Il parasitait mon update de fields et je lui trouvais pas d'utilité car definitions a priori ne change qu'après un refrech (fetchTables), et en immediate true en plus il passe une première fois avec une definition vide (je l'ai remarqué en voulant faire le clear des fields dans ce watch pour faire en même temps que l'update de primaryDate et éviter que l'un écrase l'autre, et les properties étaient vide à l'ouverture du panel ce qui vidait les fields)