### PR TITLE
fix: realtime table need refresh

### DIFF
--- a/src/components/Realtime/SettingsEdit.vue
+++ b/src/components/Realtime/SettingsEdit.vue
@@ -73,11 +73,11 @@ export default {
                 ...this.settings,
                 publicData: { ...this.settings.publicData, realtimeTables },
             });
-            this.subscribeTables();
+            this.subscribeTables(realtimeTables);
         },
-        subscribeTables() {
+        subscribeTables(realtimeTables) {
             if (!this.settings.publicData.realtimeTables) return;
-            this.plugin.subscribeTables(this.settings.publicData.realtimeTables);
+            this.plugin.subscribeTables(realtimeTables);
         },
     },
 };


### PR DESCRIPTION
this.settings.publicData.realtimeTables still have the old relatimeTables config at the moment we subscribe, so I use the local config instead