### PR TITLE
fix(WW-4854): fallback to publicApiKey when privateApiKey fails in fe…

### DIFF
--- a/src/wwPlugin.js
+++ b/src/wwPlugin.js
@@ -381,11 +381,21 @@ export default {
         }
 
         try {
-            const doc = await getDoc(runtimeProjectUrl, config.privateApiKey, {
-                branchSlug: config.branchSlug,
-            });
-            this.doc = doc;
-            const rowCount = Array.isArray(doc) ? doc.length : undefined;
+            try {
+                const doc = await getDoc(runtimeProjectUrl, config.privateApiKey, {
+                    branchSlug: config.branchSlug,
+                });
+                this.doc = doc;
+            } catch (error) {
+                if (config.publicApiKey) {
+                    const doc = await getDoc(runtimeProjectUrl, config.publicApiKey, {
+                        branchSlug: config.branchSlug,
+                    });
+                    this.doc = doc;
+                } else {
+                    throw error;
+                }
+            }
         } catch (error) {
             console.warn('[Supabase plugin] fetchDoc failed', {
                 projectUrl: runtimeProjectUrl,


### PR DESCRIPTION
…tchDoc

For self-hosted Supabase instances that don't have the /rest/v1/ anon key restriction, the privateApiKey may fail. Fall back to publicApiKey to maintain compatibility.